### PR TITLE
Improved new record behaviour heuristic

### DIFF
--- a/datasync.js
+++ b/datasync.js
@@ -230,7 +230,7 @@ const APPEND_NEW_RECORD = 0;
 const PREPEND_NEW_RECORD = 1;
 
 class DataSubscription {
-    constructor(query) {
+    constructor(query, options = null) {
         if (typeof query !== "object" || !('table' in query)) {
             throw new Error("Query passed to `new DataSubscription(..)` doesn't look like a query object. If you're using the `query()` functions to costruct the object, make sure you pass the `.query` property, like this: `new DataSubscription(query('my_table').orderBy('createdAt').query)`");
         }
@@ -254,7 +254,7 @@ class DataSubscription {
         this.onMessage = this.onMessage.bind(this);
 
         // When a new record is inserted, do we put it at the end or at the beginning?
-        this.newRecordBehaviour = this.detectNewRecordBehaviour();
+        this.newRecordBehaviour = (options && 'newRecordBehaviour' in options) ? options.newRecordBehaviour : this.detectNewRecordBehaviour();
         
         this.optimisticCreatedPendingRecordIds = [];
     }

--- a/datasync.js
+++ b/datasync.js
@@ -268,7 +268,9 @@ class DataSubscription {
             return PREPEND_NEW_RECORD;
         }
 
-        return APPEND_NEW_RECORD;
+        const isOrderByDesc = this.query.orderByClause.length > 0 && this.query.orderByClause[0].orderByDirection === 'Desc';
+
+        return isOrderByDesc ? APPEND_NEW_RECORD : PREPEND_NEW_RECORD;
     }
 
     async createOnServer() {

--- a/thin-backend-react/index.tsx
+++ b/thin-backend-react/index.tsx
@@ -35,7 +35,7 @@ const recordsCache = new Map();
  * @example
  * const messages = useQuery(query('messages').orderBy('createdAt'));
  */
-export function useQuery(queryBuilder) {
+export function useQuery(queryBuilder, options = null) {
     const [records, setRecords] = useState(() => {
         const strinigifiedQuery = JSON.stringify(queryBuilder.query);
         const cachedRecords = recordsCache.get(strinigifiedQuery);
@@ -54,7 +54,7 @@ export function useQuery(queryBuilder) {
         // Invalidate existing records, as the query might have been changed
         setRecords(cachedRecords === undefined ? null : cachedRecords);
 
-        const dataSubscription = new DataSubscription(queryBuilder.query);
+        const dataSubscription = new DataSubscription(queryBuilder.query, options);
         dataSubscription.createOnServer();
 
         // The dataSubscription is automatically closed when the last subscriber on


### PR DESCRIPTION
New records are now appended or prepended based on the primary sort order direction.

Example:

```javascript
// With these changes, the new task appears at the start of the list
const completedTasksFirst = useQuery(query('tasks').orderBy('isCompleted'));

// New tasks appears at the end
const completedTasksLast = useQuery(query('tasks').orderByAsc('isCompleted'));
```

It's now also possible to override the implicit default by passing an operation as the second argument to `useQuery`:


```javascript
import { NewRecordBehaviour } from 'thin-backend';

const completedTasksFirst = useQuery(query('tasks').orderBy('isCompleted'), {
    newRecordBehaviour: NewRecordBehaviour.APPEND_NEW_RECORD
});
```